### PR TITLE
fix: local access

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -22,6 +22,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Schema::defaultStringLength(191); //追加
-        URL::forceScheme('https'); //追加
+        URL::forceScheme('http'); //追加
     }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,11 @@ import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 
 export default defineConfig({
+    server: {
+        hmr: {
+            host: 'localhost',
+        },
+    },
     plugins: [
         laravel({
             input: [


### PR DESCRIPTION
## https→httpへ
urlスキームが`https`に強制するようになっていたため、routerが生成するurlが`https://localhost/login`などになっていた。 なお本来は、ハードコーディングせずに環境変数などから読み込みするようにすべき

## viteのCSSを読み込み可能とする
デフォルトのviteのオリジンが`http://0.0.0.0:5173`となっているが、これではlocalhostでアクセスできないため、viteのオリジンが`http://localhost:5173`となるように設定を変更